### PR TITLE
[Security/Patch] Implementing security options on wkhtmltopdf

### DIFF
--- a/lib/eml_to_pdf/configuration.rb
+++ b/lib/eml_to_pdf/configuration.rb
@@ -9,6 +9,11 @@ module EmlToPdf
       @date_label = "Date"
       @date_format = lambda { |date| date.strftime("%Y-%m-%d %H:%M:%S %z") }
       @wkhtmltopdf = 'wkhtmltopdf'
+      @security_options = %w[
+        --disable-local-file-access
+        --disable-internal-links
+        --disable-external-links
+      ]
       @timeout = 0
     end
 

--- a/lib/eml_to_pdf/wkhtmltopdf.rb
+++ b/lib/eml_to_pdf/wkhtmltopdf.rb
@@ -10,8 +10,17 @@ module EmlToPdf
     end
 
     def self.convert(input, output_path)
+      security_options = ""
+      EmlToPdf.configuration.security_options.each do |option|
+        security_options += "#{option} "
+      end
+      os_command = <<~INFO
+        #{EmlToPdf.configuration.wkhtmltopdf} #{security_options}
+        --encoding utf-8 --footer-center [page] --footer-spacing 2.5 --quiet - #{output_path} 2>&1
+      INFO
+      os_command.gsub!("\n", '')
       Timeout.timeout(EmlToPdf.configuration.timeout, ConversionTimeoutError) do
-        IO.popen("#{EmlToPdf.configuration.wkhtmltopdf} --encoding utf-8 --footer-center [page] --footer-spacing 2.5 --quiet - #{output_path} 2>&1", "r+") do |pipe|
+        IO.popen(os_command, "r+") do |pipe|
           pipe.puts(input)
           pipe.close_write
           output = pipe.readlines.join


### PR DESCRIPTION
## Description, Reasoning and Context

As EmlToPdf gem isn't shipped with a way to add custom options to `wkhtmltopdf`. I added security options to avoid the exploitation of vulnerabilities such as LFI/SSRF.

## Kind of change

- **Security bugfix** (harden the configuration of current `wkhtmltopdf` usage)
